### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: deploy
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/MrGuato/Valheim_Game_Server/security/code-scanning/4](https://github.com/MrGuato/Valheim_Game_Server/security/code-scanning/4)

To fix the problem, you should add a `permissions` key to the workflow so that the GITHUB_TOKEN is granted only the minimal required scope. Since the workflow is only checking out code and running a local shell script, the minimal needed scope is just `contents: read`, allowing checkout of private repositories if required. You can add the permissions block either at the job `deploy` level or at the root (the top level of the workflow, just after `name:` but before `jobs:`). To minimize duplication and follow best practices, placing it at the root applies it to all jobs (here, only `deploy`). Edit `.github/workflows/deploy.yml` by adding:

```yaml
permissions:
  contents: read
```

after the `name: deploy` line. No imports, definitions, or further changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
